### PR TITLE
BFS visualization

### DIFF
--- a/src/pages/algorithms/breadthFirstSearch.ts
+++ b/src/pages/algorithms/breadthFirstSearch.ts
@@ -2,6 +2,8 @@ interface BFSNodeStep {
     node: number // node currently being processed
     queue: number[] // queue of nodes to visit
     visited: number[] // list of nodes visited
+    dequeuedNodes: number[] // list of processed nodes
+    graph: number[][] //
 }
 
 // implementation for graph traversal to record each step
@@ -19,17 +21,30 @@ export const breadthFirstSearch = (
     const steps: BFSNodeStep[] = [] // empty array to hold the steps of the algo
     const queue: number[] = [start] // initialize the queue with the starting node
     const visited: boolean[] = new Array(graph.length).fill(false) // track visited nodes
+    const dequeuedNodes: number[] = [] // initialize dequeued nodes list
     visited[start] = true // mark the starting node as visited
 
     // continue processing nodes while there are still nodes in the queue
     while (queue.length > 0) {
-        const node = queue.shift()! // dequeue the next node
+        // push before dequeueing to capture current state
+        steps.push({
+            node: queue[0], // current node that will be processed
+            queue: [...queue], // copy of the current queue state
+            visited: visited.map((v, i) => (v ? i : -1)).filter(i => i !== -1), // record visited nodes
+            dequeuedNodes: [...dequeuedNodes], // copy of current dequeued nodes
+            graph: graph,
+        })
 
-        // push current step to the steps array for visualization
+        const node = queue.shift()! // dequeue the next node
+        dequeuedNodes.push(node) // add the node th dequeued nodes
+
+        // push after dequeueing to capture updated state
         steps.push({
             node, // current node being processed
             queue: [...queue], // copy of the current queue state
             visited: visited.map((v, i) => (v ? i : -1)).filter(i => i !== -1), // record visited nodes
+            dequeuedNodes: [...dequeuedNodes], // copy of current dequeued nodes
+            graph: graph,
         })
 
         // if the target node is found, exit the loop


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add BFS visualization with animated node and edge rendering using `framer-motion`.
> 
>   - **Behavior**:
>     - Adds `dequeuedNodes` and `graph` to `BFSNodeStep` in `breadthFirstSearch.ts` for visualization.
>     - Updates `breadthFirstSearch()` to record steps before and after dequeuing nodes.
>   - **Visualization**:
>     - Adds `renderBFSStep()` in `index.tsx` to visualize BFS steps with nodes and edges using `framer-motion`.
>     - Displays queue and processed nodes with animations.
>   - **Misc**:
>     - Renames `renderGraphSearchStep()` to `renderDFSStep()` in `index.tsx`.
>     - Imports `steps` from `framer-motion` in `index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fractal-bootcamp%2Ffaisal-algorithms&utm_source=github&utm_medium=referral)<sup> for 590f79545822f1fd2949efb6daacc585fb330577. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->